### PR TITLE
feat: Phase 4 AIエージェント実験ループ実装 (#32)

### DIFF
--- a/ai_filter/claude_agent.py
+++ b/ai_filter/claude_agent.py
@@ -1,0 +1,128 @@
+"""Claude API を使った実験提案エージェント
+
+過去の実験結果（MLflow）を読み取り、次に試すべき実験設定を提案する。
+"""
+
+import json
+import logging
+import os
+from typing import Any
+
+import anthropic
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_PROMPT = """あなたは競馬予測モデルの実験を設計するAIエージェントです。
+
+## 目標
+- 単勝回収率（win_recovery）を最大化する。100% 以上が達成目標。
+- AUC が 0.75 を下回る実験設定は採用しない。
+
+## あなたの役割
+過去の実験結果を分析し、次に試すべき実験設定を JSON で提案してください。
+
+## 探索対象パラメータ
+- LightGBM パラメータ: num_leaves (15〜127), scale_pos_weight (5〜30), learning_rate (0.01〜0.1), min_child_samples (20〜100), feature_fraction (0.5〜1.0)
+- ev_threshold: EV閾値 (0.8〜2.0) — 高くするほど買い目を絞る
+- feature_subset: 使用する特徴量リスト（null の場合は全特徴量）
+
+## 出力フォーマット（必ず JSON で出力）
+```json
+{
+  "action": "continue" または "stop",
+  "rationale": "この実験設定を試す理由・仮説",
+  "config": {
+    "win_params": {"num_leaves": 63, "scale_pos_weight": 13, ...},
+    "ev_threshold": 1.0,
+    "feature_subset": null
+  }
+}
+```
+
+action が "stop" の場合は収束と判断してループを終了します。
+"""
+
+
+def fetch_experiment_history() -> list[dict[str, Any]]:
+    """MLflow から過去の実験結果を取得する。"""
+    import mlflow  # noqa: PLC0415
+
+    client = mlflow.tracking.MlflowClient()
+    experiments = client.search_experiments(filter_string="name LIKE 'phase4%'")
+
+    history = []
+    for exp in experiments:
+        runs = client.search_runs(
+            experiment_ids=[exp.experiment_id],
+            order_by=["start_time DESC"],
+            max_results=50,
+        )
+        for run in runs:
+            if run.data.metrics:
+                history.append(
+                    {
+                        "run_id": run.info.run_id,
+                        "run_name": run.info.run_name,
+                        "params": run.data.params,
+                        "metrics": run.data.metrics,
+                    }
+                )
+
+    return history
+
+
+def suggest_next_experiment(
+    history: list[dict[str, Any]],
+    iteration: int,
+) -> dict[str, Any]:
+    """Claude API を使って次の実験設定を提案する。"""
+    client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+
+    # 過去の実験をサマリー形式に変換
+    if history:
+        history_text = "## 過去の実験結果\n\n"
+        for h in history[-20:]:  # 直近20件
+            metrics = h.get("metrics", {})
+            params = h.get("params", {})
+            history_text += (
+                f"- run: {h['run_name']}\n"
+                f"  params: num_leaves={params.get('num_leaves', '?')}, "
+                f"scale_pos_weight={params.get('scale_pos_weight', '?')}, "
+                f"ev_threshold={params.get('ev_threshold', '?')}\n"
+                f"  metrics: win_AUC={metrics.get('mean_win_auc', '?'):.4f}, "
+                f"win_recovery={metrics.get('mean_win_recovery', '?'):.1f}%\n"
+            )
+    else:
+        history_text = (
+            "## 過去の実験結果\n\nまだ実験データがありません。最初の実験を提案してください。\n"
+        )
+
+    user_message = f"""{history_text}
+
+## 現在のイテレーション
+{iteration + 1} 回目の実験提案をお願いします。
+
+過去の結果を踏まえて、win_recovery を改善できると考える次の実験設定を JSON で提案してください。
+連続 5 回改善なしまたは win_recovery > 100% 達成の場合は action を "stop" にしてください。
+"""
+
+    response = client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=1024,
+        system=SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": user_message}],
+    )
+
+    # JSON を抽出
+    content = response.content[0].text
+    # コードブロック内の JSON を取得
+    if "```json" in content:
+        json_str = content.split("```json")[1].split("```")[0].strip()
+    elif "```" in content:
+        json_str = content.split("```")[1].split("```")[0].strip()
+    else:
+        json_str = content.strip()
+
+    proposal = json.loads(json_str)
+    logger.info("Claude proposal: %s", json.dumps(proposal, ensure_ascii=False, indent=2))
+    return proposal

--- a/ai_filter/experiment_loop.py
+++ b/ai_filter/experiment_loop.py
@@ -1,0 +1,133 @@
+"""Phase 4 AIエージェント実験ループ
+
+Claude API が実験設定を提案 → train.py で実行 → MLflow に記録 → 繰り返す。
+
+実行例:
+    python ai_filter/experiment_loop.py
+    python ai_filter/experiment_loop.py --max-iterations 30
+"""
+
+import argparse
+import json
+import logging
+from datetime import date
+
+import mlflow
+from ai_filter.claude_agent import fetch_experiment_history, suggest_next_experiment
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+EXPERIMENT_NAME = "phase4_ai_loop"
+
+
+def run_experiment(config: dict, df) -> dict:
+    """1回の実験を実行して結果を返す。"""
+    from model.train import walk_forward_validation  # noqa: PLC0415
+
+    win_params = config.get("win_params")
+    ev_threshold = config.get("ev_threshold", 1.0)
+    feature_subset = config.get("feature_subset")
+
+    summary = walk_forward_validation(
+        df,
+        win_params=win_params,
+        ev_threshold=ev_threshold,
+        feature_subset=feature_subset,
+    )
+    return summary
+
+
+def run_loop(max_iterations: int = 20) -> None:
+    """AIエージェント実験ループを実行する。"""
+
+    from features.feature_builder import build_training_dataset  # noqa: PLC0415
+    from model.train import DATA_START  # noqa: PLC0415
+
+    logger.info("Loading training data...")
+    df = build_training_dataset(DATA_START, date.today())
+
+    if df.empty:
+        logger.error("No training data. Abort.")
+        return
+
+    mlflow.set_experiment(EXPERIMENT_NAME)
+
+    best_recovery = float("-inf")
+    no_improve_count = 0
+
+    for iteration in range(max_iterations):
+        logger.info("=== Iteration %d / %d ===", iteration + 1, max_iterations)
+
+        # 過去の実験履歴を取得
+        history = fetch_experiment_history()
+
+        # Claude に次の実験を提案させる
+        proposal = suggest_next_experiment(history, iteration)
+
+        if proposal.get("action") == "stop":
+            logger.info("Claude decided to stop: %s", proposal.get("rationale"))
+            break
+
+        config = proposal.get("config", {})
+        rationale = proposal.get("rationale", "")
+        logger.info("Rationale: %s", rationale)
+
+        # 実験実行
+        with mlflow.start_run(run_name=f"phase4_iter_{iteration + 1:02d}"):
+            mlflow.log_param("iteration", iteration + 1)
+            mlflow.log_param("rationale", rationale)
+            mlflow.log_param("ev_threshold", config.get("ev_threshold", 1.0))
+            if config.get("win_params"):
+                for k, v in config["win_params"].items():
+                    mlflow.log_param(k, v)
+            if config.get("feature_subset"):
+                mlflow.log_param("feature_subset", json.dumps(config["feature_subset"]))
+
+            summary = run_experiment(config, df)
+
+            mlflow.log_metrics(
+                {
+                    "mean_win_auc": summary["mean_win_auc"],
+                    "mean_place_auc": summary["mean_place_auc"],
+                    "mean_win_recovery": summary["mean_win_recovery"],
+                    "mean_place_recovery": summary["mean_place_recovery"],
+                }
+            )
+
+        win_recovery = summary["mean_win_recovery"]
+        logger.info(
+            "Result: win_AUC=%.4f win_recovery=%.1f%%",
+            summary["mean_win_auc"],
+            win_recovery,
+        )
+
+        # 改善チェック
+        if win_recovery > best_recovery:
+            best_recovery = win_recovery
+            no_improve_count = 0
+            logger.info("New best win_recovery: %.1f%%", best_recovery)
+        else:
+            no_improve_count += 1
+            logger.info("No improvement (%d / 5)", no_improve_count)
+
+        if no_improve_count >= 5:
+            logger.info("No improvement for 5 iterations. Stopping.")
+            break
+
+        if win_recovery >= 100.0 and summary["mean_win_auc"] >= 0.75:
+            logger.info("Target achieved! win_recovery=%.1f%%", win_recovery)
+            break
+
+    logger.info("Loop finished. Best win_recovery: %.1f%%", best_recovery)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Phase 4 AIエージェント実験ループ")
+    parser.add_argument("--max-iterations", type=int, default=20, help="最大イテレーション数")
+    args = parser.parse_args()
+    run_loop(args.max_iterations)
+
+
+if __name__ == "__main__":
+    main()

--- a/model/train.py
+++ b/model/train.py
@@ -14,6 +14,7 @@
 """
 
 import argparse
+import json
 import logging
 from datetime import date, datetime
 
@@ -215,11 +216,22 @@ def walk_forward_validation(
     df: pd.DataFrame,
     val_start: int = 2020,
     val_end: int = 2024,
+    win_params: dict | None = None,
+    ev_threshold: float = 1.0,
+    feature_subset: list[str] | None = None,
 ) -> dict:
     """ウォークフォワード検証を実行し、各ステップの指標を返す。"""
     results = []
-    feat_cols = _get_feature_cols(df)
+    # 特徴量サブセット指定がある場合はそちらを優先
+    if feature_subset:
+        feat_cols = [c for c in feature_subset if c in df.columns]
+    else:
+        feat_cols = _get_feature_cols(df)
     cat_cols = [c for c in CATEGORICAL_COLS if c in feat_cols]
+
+    # パラメータ上書き
+    _win_params = {**WIN_PARAMS, **(win_params or {})}
+    _place_params = {**PLACE_PARAMS, **(win_params or {})}
 
     df = _coerce_feature_dtypes(df, feat_cols)
     df["held_year"] = pd.to_datetime(df["held_date"]).dt.year
@@ -248,12 +260,12 @@ def walk_forward_validation(
         )
 
         # 単勝モデル
-        win_model = _train_model(X_train, train_df["win_label"], WIN_PARAMS, weights, cat_cols)
+        win_model = _train_model(X_train, train_df["win_label"], _win_params, weights, cat_cols)
         val_df["win_proba_raw"] = win_model.predict(X_val)
 
         # 複勝モデル
         place_model = _train_model(
-            X_train, train_df["place_label"], PLACE_PARAMS, weights, cat_cols
+            X_train, train_df["place_label"], _place_params, weights, cat_cols
         )
         val_df["place_proba_raw"] = place_model.predict(X_val)
 
@@ -272,7 +284,9 @@ def walk_forward_validation(
         place_auc = roc_auc_score(val_df["place_label"], val_df["place_proba_raw"])
 
         # 回収率（単勝: EV閾値、複勝: 生確率閾値）
-        win_recovery = compute_recovery_rate(val_df, "win_proba", "win_odds", "win_label")
+        win_recovery = compute_recovery_rate(
+            val_df, "win_proba", "win_odds", "win_label", ev_threshold
+        )
         place_recovery = compute_place_recovery_rate(val_df, "place_proba_raw", "place_label")
 
         step = {
@@ -303,8 +317,12 @@ def walk_forward_validation(
                     "val_year": val_year,
                     "train_rows": len(train_df),
                     "num_features": len(feat_cols),
-                    "num_leaves": WIN_PARAMS["num_leaves"],
-                    "learning_rate": WIN_PARAMS["learning_rate"],
+                    "num_leaves": _win_params["num_leaves"],
+                    "learning_rate": _win_params["learning_rate"],
+                    "scale_pos_weight": _win_params.get(
+                        "scale_pos_weight", WIN_PARAMS["scale_pos_weight"]
+                    ),
+                    "ev_threshold": ev_threshold,
                 }
             )
             mlflow.log_metrics(
@@ -363,7 +381,21 @@ def main() -> None:
         "--val-start", type=int, default=2020, help="検証開始年（デフォルト: 2020）"
     )
     parser.add_argument("--val-end", type=int, default=2024, help="検証終了年（デフォルト: 2024）")
+    parser.add_argument(
+        "--win-params",
+        type=str,
+        default=None,
+        help="LightGBM パラメータ上書き（JSON文字列, 例: '{\"num_leaves\": 31}'）",
+    )
+    parser.add_argument(
+        "--ev-threshold",
+        type=float,
+        default=1.0,
+        help="単勝 EV 閾値（デフォルト: 1.0）",
+    )
     args = parser.parse_args()
+
+    win_params_override = json.loads(args.win_params) if args.win_params else None
 
     from features.feature_builder import build_training_dataset  # noqa: PLC0415
 
@@ -378,7 +410,13 @@ def main() -> None:
         import mlflow  # noqa: PLC0415
 
         with mlflow.start_run(run_name="walk_forward"):
-            summary = walk_forward_validation(df, args.val_start, args.val_end)
+            summary = walk_forward_validation(
+                df,
+                args.val_start,
+                args.val_end,
+                win_params=win_params_override,
+                ev_threshold=args.ev_threshold,
+            )
             mlflow.log_metrics(
                 {
                     "mean_win_auc": summary["mean_win_auc"],


### PR DESCRIPTION
## Summary

- `model/train.py`: `--win-params` / `--ev-threshold` 引数を追加。`walk_forward_validation()` に外部パラメータ注入対応
- `ai_filter/claude_agent.py`: MLflow 実験履歴を読み取り、Claude API（claude-opus-4-6）が次の実験設定を JSON で提案
- `ai_filter/experiment_loop.py`: ループ制御（最大イテレーション・連続5回改善なしで停止・win_recovery>100%で成功終了）

## 使い方

```bash
# 実験ループ実行（デフォルト20イテレーション）
docker compose exec app python ai_filter/experiment_loop.py

# イテレーション数指定
docker compose exec app python ai_filter/experiment_loop.py --max-iterations 30
```

## 環境変数

`ANTHROPIC_API_KEY` が必要（docker-compose.yml の環境変数に設定）

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)