### PR TITLE
feat: Phase 4 redesign — Optuna + SHAP + Claude feature suggestion loop

### DIFF
--- a/ai_filter/claude_agent.py
+++ b/ai_filter/claude_agent.py
@@ -1,50 +1,131 @@
-"""Claude API を使った実験提案エージェント
+"""Claude API を使った SHAP 解釈・特徴量提案エージェント
 
-過去の実験結果（MLflow）を読み取り、次に試すべき実験設定を提案する。
+SHAP による特徴量重要度を解釈し、次のバージョンで追加すべき特徴量を提案する。
+ノウハウは ai_filter/knowhow.md に蓄積される。
 """
 
 import json
 import logging
 import os
+from pathlib import Path
 from typing import Any
 
 import anthropic
 
 logger = logging.getLogger(__name__)
 
-SYSTEM_PROMPT = """あなたは競馬予測モデルの実験を設計するAIエージェントです。
+KNOWHOW_PATH = Path(__file__).parent / "knowhow.md"
 
-## 目標
-- 単勝回収率（win_recovery）を最大化する。100% 以上が達成目標。
-- AUC が 0.75 を下回る実験設定は採用しない。
+SYSTEM_PROMPT = """あなたは競馬予測モデルの特徴量エンジニアリングを支援するAIです。
 
 ## あなたの役割
-過去の実験結果を分析し、次に試すべき実験設定を JSON で提案してください。
-
-## 探索対象パラメータ
-- LightGBM パラメータ: num_leaves (15〜127), scale_pos_weight (5〜30), learning_rate (0.01〜0.1), min_child_samples (20〜100), feature_fraction (0.5〜1.0)
-- ev_threshold: EV閾値 (0.8〜2.0) — 高くするほど買い目を絞る
-- feature_subset: 使用する特徴量リスト（null の場合は全特徴量）
+SHAP による特徴量重要度分析を解釈し、モデルの予測精度（特に単勝回収率）を改善するための
+新しい特徴量を提案してください。
 
 ## 出力フォーマット（必ず JSON で出力）
 ```json
 {
-  "action": "continue" または "stop",
-  "rationale": "この実験設定を試す理由・仮説",
-  "config": {
-    "win_params": {"num_leaves": 63, "scale_pos_weight": 13, ...},
-    "ev_threshold": 1.0,
-    "feature_subset": null
-  }
+  "interpretation": "SHAP 結果から読み取れる洞察（競馬ドメイン知識を含む）",
+  "feature_suggestions": [
+    {
+      "name": "特徴量名（snake_case）",
+      "rationale": "なぜこの特徴量が有効か（競馬的根拠）",
+      "computation": "どう計算するか（SQL/Python の擬似コード）"
+    }
+  ],
+  "knowhow_update": "今回の実験から学んだノウハウ（次回の参考に）"
 }
 ```
 
-action が "stop" の場合は収束と判断してループを終了します。
+## 注意
+- 既に実装されている特徴量は提案しない
+- 1回の提案は 2〜3 特徴量に絞る（多すぎると実装負荷が高い）
+- DBから取得できるデータの範囲で考える（races, entries, results, odds テーブル）
 """
 
 
+def load_knowhow() -> str:
+    """蓄積されたノウハウファイルを読み込む。"""
+    if KNOWHOW_PATH.exists():
+        return KNOWHOW_PATH.read_text(encoding="utf-8")
+    return "（まだノウハウはありません）"
+
+
+def append_knowhow(new_knowhow: str, iteration: int) -> None:
+    """ノウハウファイルに追記する。"""
+    from datetime import date  # noqa: PLC0415
+
+    entry = f"\n## 実験 {iteration}（{date.today()}）\n{new_knowhow}\n"
+    with open(KNOWHOW_PATH, "a", encoding="utf-8") as f:
+        f.write(entry)
+
+
+def interpret_shap_and_suggest(
+    shap_text: str,
+    metrics: dict[str, float],
+    existing_features: list[str],
+    iteration: int,
+) -> dict[str, Any]:
+    """SHAP サマリーを Claude に渡して解釈・特徴量提案を得る。
+
+    Args:
+        shap_text: format_shap_for_claude() の出力
+        metrics: {"mean_win_auc": ..., "mean_win_recovery": ...}
+        existing_features: 現在の特徴量リスト
+        iteration: 現在のイテレーション番号
+
+    Returns:
+        Claude の提案 dict（interpretation, feature_suggestions, knowhow_update）
+    """
+    client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+    knowhow = load_knowhow()
+
+    user_message = f"""{shap_text}
+
+## 現在のモデル性能
+- win_AUC: {metrics.get("mean_win_auc", "?"):.4f}
+- win_recovery: {metrics.get("mean_win_recovery", "?"):.1f}%
+- place_recovery: {metrics.get("mean_place_recovery", "?"):.1f}%
+
+## 現在の特徴量リスト
+{", ".join(existing_features)}
+
+## 蓄積されたノウハウ
+{knowhow}
+
+## お願い
+上記の SHAP 分析・モデル性能・過去のノウハウを踏まえて、
+win_recovery を 100% 以上にするために追加すべき特徴量を提案してください。
+"""
+
+    response = client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=2048,
+        system=SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": user_message}],
+    )
+
+    content = response.content[0].text
+    # JSON を抽出
+    if "```json" in content:
+        json_str = content.split("```json")[1].split("```")[0].strip()
+    elif "```" in content:
+        json_str = content.split("```")[1].split("```")[0].strip()
+    else:
+        json_str = content.strip()
+
+    proposal = json.loads(json_str)
+    logger.info("Claude proposal:\n%s", json.dumps(proposal, ensure_ascii=False, indent=2))
+
+    # ノウハウを保存
+    if proposal.get("knowhow_update"):
+        append_knowhow(proposal["knowhow_update"], iteration)
+
+    return proposal
+
+
 def fetch_experiment_history() -> list[dict[str, Any]]:
-    """MLflow から過去の実験結果を取得する。"""
+    """MLflow から phase4 実験の履歴を取得する（後方互換のため残す）。"""
     import mlflow  # noqa: PLC0415
 
     client = mlflow.tracking.MlflowClient()
@@ -58,77 +139,17 @@ def fetch_experiment_history() -> list[dict[str, Any]]:
             max_results=50,
         )
         for run in runs:
-            if run.data.metrics:
-                history.append(
-                    {
-                        "run_id": run.info.run_id,
-                        "run_name": run.info.run_name,
-                        "params": run.data.params,
-                        "metrics": run.data.metrics,
-                    }
-                )
-
-    return history
-
-
-def suggest_next_experiment(
-    history: list[dict[str, Any]],
-    iteration: int,
-) -> dict[str, Any]:
-    """Claude API を使って次の実験設定を提案する。"""
-    client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
-
-    # 過去の実験をサマリー形式に変換
-    if history:
-        history_text = "## 過去の実験結果\n\n"
-        for h in history[-20:]:  # 直近20件
-            metrics = h.get("metrics", {})
-            params = h.get("params", {})
-            # mean_win_auc / mean_win_recovery がない run（nested step など）はスキップ
-            win_auc = metrics.get("mean_win_auc")
-            win_rec = metrics.get("mean_win_recovery")
+            win_auc = run.data.metrics.get("mean_win_auc")
+            win_rec = run.data.metrics.get("mean_win_recovery")
             if win_auc is None or win_rec is None:
                 continue
-            history_text += (
-                f"- run: {h['run_name']}\n"
-                f"  params: num_leaves={params.get('num_leaves', '?')}, "
-                f"scale_pos_weight={params.get('scale_pos_weight', '?')}, "
-                f"ev_threshold={params.get('ev_threshold', '?')}\n"
-                f"  metrics: win_AUC={win_auc:.4f}, win_recovery={win_rec:.1f}%\n"
+            history.append(
+                {
+                    "run_id": run.info.run_id,
+                    "run_name": run.info.run_name,
+                    "params": run.data.params,
+                    "metrics": run.data.metrics,
+                }
             )
-        if not history_text.strip().endswith("\n\n"):
-            history_text = history_text or "## 過去の実験結果\n\nまだ集計データがありません。\n"
-    else:
-        history_text = (
-            "## 過去の実験結果\n\nまだ実験データがありません。最初の実験を提案してください。\n"
-        )
 
-    user_message = f"""{history_text}
-
-## 現在のイテレーション
-{iteration + 1} 回目の実験提案をお願いします。
-
-過去の結果を踏まえて、win_recovery を改善できると考える次の実験設定を JSON で提案してください。
-連続 5 回改善なしまたは win_recovery > 100% 達成の場合は action を "stop" にしてください。
-"""
-
-    response = client.messages.create(
-        model="claude-opus-4-6",
-        max_tokens=1024,
-        system=SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": user_message}],
-    )
-
-    # JSON を抽出
-    content = response.content[0].text
-    # コードブロック内の JSON を取得
-    if "```json" in content:
-        json_str = content.split("```json")[1].split("```")[0].strip()
-    elif "```" in content:
-        json_str = content.split("```")[1].split("```")[0].strip()
-    else:
-        json_str = content.strip()
-
-    proposal = json.loads(json_str)
-    logger.info("Claude proposal: %s", json.dumps(proposal, ensure_ascii=False, indent=2))
-    return proposal
+    return history

--- a/ai_filter/experiment_loop.py
+++ b/ai_filter/experiment_loop.py
@@ -1,48 +1,71 @@
-"""Phase 4 AIエージェント実験ループ
+"""Phase 4 実験ループ: Optuna パラメータ最適化 + SHAP 解析 + Claude 特徴量提案
 
-Claude API が実験設定を提案 → train.py で実行 → MLflow に記録 → 繰り返す。
+フロー:
+  フェーズ A: Optuna でハイパーパラメータを最適化
+  フェーズ B: 最良パラメータで SHAP 解析
+  フェーズ C: Claude が SHAP を解釈し、新特徴量を提案
 
 実行例:
     python ai_filter/experiment_loop.py
-    python ai_filter/experiment_loop.py --max-iterations 30
+    python ai_filter/experiment_loop.py --optuna-trials 30 --max-iterations 5
 """
 
 import argparse
-import json
 import logging
 from datetime import date
 
-import mlflow
-from ai_filter.claude_agent import fetch_experiment_history, suggest_next_experiment
+from ai_filter.claude_agent import interpret_shap_and_suggest
+from ai_filter.optuna_tuner import optimize
+from ai_filter.shap_analyzer import compute_shap_summary, format_shap_for_claude
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
-EXPERIMENT_NAME = "phase4_ai_loop"
+
+def run_shap_analysis(df, best_params: dict) -> tuple[list[dict], dict]:
+    """最良パラメータでモデルを学習し、SHAP サマリーと検証メトリクスを返す。
+
+    Args:
+        df: 学習データ DataFrame
+        best_params: Optuna で得た最良パラメータ（win_params + ev_threshold）
+
+    Returns:
+        (shap_summary, metrics)
+        - shap_summary: compute_shap_summary の出力（feature, mean_abs_shap, mean_shap, rank）
+        - metrics: mean_win_auc, mean_win_recovery, mean_place_recovery
+    """
+    from model.train import FEATURE_COLS, WIN_PARAMS, walk_forward_validation  # noqa: PLC0415
+
+    ev_threshold = best_params.pop("ev_threshold", 1.0)
+    win_params = {**WIN_PARAMS, **best_params}
+
+    # walk-forward で検証メトリクスを取得（最後の fold のモデルを SHAP に使う）
+    summary = walk_forward_validation(df, win_params=win_params, ev_threshold=ev_threshold)
+    metrics = {
+        "mean_win_auc": summary["mean_win_auc"],
+        "mean_win_recovery": summary["mean_win_recovery"],
+        "mean_place_recovery": summary["mean_place_recovery"],
+    }
+
+    # 最後の fold のモデルで SHAP を計算
+    import lightgbm as lgb  # noqa: PLC0415
+
+    feat_cols = [c for c in FEATURE_COLS if c in df.columns]
+    X = df[feat_cols].copy()
+
+    # 全データで再学習（SHAP は全体傾向を把握するため）
+    y = df["win_label"]
+    model = lgb.LGBMClassifier(**win_params, n_estimators=300, random_state=42, verbosity=-1)
+    model.fit(X, y)
+
+    shap_summary = compute_shap_summary(model, X)
+    return shap_summary, metrics
 
 
-def run_experiment(config: dict, df) -> dict:
-    """1回の実験を実行して結果を返す。"""
-    from model.train import walk_forward_validation  # noqa: PLC0415
-
-    win_params = config.get("win_params")
-    ev_threshold = config.get("ev_threshold", 1.0)
-    feature_subset = config.get("feature_subset")
-
-    summary = walk_forward_validation(
-        df,
-        win_params=win_params,
-        ev_threshold=ev_threshold,
-        feature_subset=feature_subset,
-    )
-    return summary
-
-
-def run_loop(max_iterations: int = 20) -> None:
-    """AIエージェント実験ループを実行する。"""
-
+def run_loop(max_iterations: int = 3, optuna_trials: int = 50) -> None:
+    """Optuna → SHAP → Claude の実験ループを実行する。"""
     from features.feature_builder import build_training_dataset  # noqa: PLC0415
-    from model.train import DATA_START  # noqa: PLC0415
+    from model.train import DATA_START, FEATURE_COLS  # noqa: PLC0415
 
     logger.info("Loading training data...")
     df = build_training_dataset(DATA_START, date.today())
@@ -51,82 +74,60 @@ def run_loop(max_iterations: int = 20) -> None:
         logger.error("No training data. Abort.")
         return
 
-    mlflow.set_experiment(EXPERIMENT_NAME)
-
-    best_recovery = float("-inf")
-    no_improve_count = 0
+    existing_features = [c for c in FEATURE_COLS if c in df.columns]
 
     for iteration in range(max_iterations):
         logger.info("=== Iteration %d / %d ===", iteration + 1, max_iterations)
 
-        # 過去の実験履歴を取得
-        history = fetch_experiment_history()
+        # フェーズ A: Optuna パラメータ最適化
+        logger.info("[Phase A] Optuna optimization (%d trials)...", optuna_trials)
+        best_params = optimize(df, n_trials=optuna_trials)
+        logger.info("Best params: %s", best_params)
 
-        # Claude に次の実験を提案させる
-        proposal = suggest_next_experiment(history, iteration)
-
-        if proposal.get("action") == "stop":
-            logger.info("Claude decided to stop: %s", proposal.get("rationale"))
-            break
-
-        config = proposal.get("config", {})
-        rationale = proposal.get("rationale", "")
-        logger.info("Rationale: %s", rationale)
-
-        # 実験実行
-        with mlflow.start_run(run_name=f"phase4_iter_{iteration + 1:02d}"):
-            mlflow.log_param("iteration", iteration + 1)
-            mlflow.log_param("rationale", rationale)
-            mlflow.log_param("ev_threshold", config.get("ev_threshold", 1.0))
-            if config.get("win_params"):
-                for k, v in config["win_params"].items():
-                    mlflow.log_param(k, v)
-            if config.get("feature_subset"):
-                mlflow.log_param("feature_subset", json.dumps(config["feature_subset"]))
-
-            summary = run_experiment(config, df)
-
-            mlflow.log_metrics(
-                {
-                    "mean_win_auc": summary["mean_win_auc"],
-                    "mean_place_auc": summary["mean_place_auc"],
-                    "mean_win_recovery": summary["mean_win_recovery"],
-                    "mean_place_recovery": summary["mean_place_recovery"],
-                }
-            )
-
-        win_recovery = summary["mean_win_recovery"]
+        # フェーズ B: SHAP 解析
+        logger.info("[Phase B] SHAP analysis with best params...")
+        shap_summary, metrics = run_shap_analysis(df, best_params.copy())
+        shap_text = format_shap_for_claude(shap_summary, top_n=15)
         logger.info(
-            "Result: win_AUC=%.4f win_recovery=%.1f%%",
-            summary["mean_win_auc"],
-            win_recovery,
+            "Metrics: win_AUC=%.4f win_recovery=%.1f%% place_recovery=%.1f%%",
+            metrics["mean_win_auc"],
+            metrics["mean_win_recovery"],
+            metrics["mean_place_recovery"],
         )
 
-        # 改善チェック
-        if win_recovery > best_recovery:
-            best_recovery = win_recovery
-            no_improve_count = 0
-            logger.info("New best win_recovery: %.1f%%", best_recovery)
-        else:
-            no_improve_count += 1
-            logger.info("No improvement (%d / 5)", no_improve_count)
+        # フェーズ C: Claude による解釈・特徴量提案
+        logger.info("[Phase C] Claude interpretation and feature suggestions...")
+        proposal = interpret_shap_and_suggest(
+            shap_text=shap_text,
+            metrics=metrics,
+            existing_features=existing_features,
+            iteration=iteration + 1,
+        )
 
-        if no_improve_count >= 5:
-            logger.info("No improvement for 5 iterations. Stopping.")
+        logger.info("=== Claude Proposal (Iteration %d) ===", iteration + 1)
+        logger.info("Interpretation: %s", proposal.get("interpretation", ""))
+        for i, feat in enumerate(proposal.get("feature_suggestions", []), start=1):
+            logger.info(
+                "  [%d] %s — %s",
+                i,
+                feat.get("name", "?"),
+                feat.get("rationale", ""),
+            )
+            logger.info("       Computation: %s", feat.get("computation", ""))
+
+        if metrics["mean_win_recovery"] >= 100.0 and metrics["mean_win_auc"] >= 0.75:
+            logger.info("Target achieved! win_recovery=%.1f%%", metrics["mean_win_recovery"])
             break
 
-        if win_recovery >= 100.0 and summary["mean_win_auc"] >= 0.75:
-            logger.info("Target achieved! win_recovery=%.1f%%", win_recovery)
-            break
-
-    logger.info("Loop finished. Best win_recovery: %.1f%%", best_recovery)
+    logger.info("Loop finished.")
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Phase 4 AIエージェント実験ループ")
-    parser.add_argument("--max-iterations", type=int, default=20, help="最大イテレーション数")
+    parser = argparse.ArgumentParser(description="Phase 4 Optuna+SHAP+Claude 実験ループ")
+    parser.add_argument("--max-iterations", type=int, default=3, help="最大イテレーション数")
+    parser.add_argument("--optuna-trials", type=int, default=50, help="Optuna 試行回数")
     args = parser.parse_args()
-    run_loop(args.max_iterations)
+    run_loop(max_iterations=args.max_iterations, optuna_trials=args.optuna_trials)
 
 
 if __name__ == "__main__":

--- a/ai_filter/optuna_tuner.py
+++ b/ai_filter/optuna_tuner.py
@@ -1,0 +1,104 @@
+"""Optuna によるハイパーパラメータ最適化
+
+walk-forward 検証の win_recovery を最大化するパラメータを探索する。
+
+実行例:
+    python ai_filter/optuna_tuner.py --n-trials 50
+    python ai_filter/optuna_tuner.py --n-trials 30 --output best_params.json
+"""
+
+import argparse
+import json
+import logging
+from datetime import date
+
+import optuna
+
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def build_objective(df):
+    """Optuna の objective 関数を返す。"""
+    from model.train import walk_forward_validation  # noqa: PLC0415
+
+    def objective(trial: optuna.Trial) -> float:
+        win_params = {
+            "num_leaves": trial.suggest_int("num_leaves", 15, 127),
+            "scale_pos_weight": trial.suggest_float("scale_pos_weight", 5.0, 30.0),
+            "learning_rate": trial.suggest_float("learning_rate", 0.01, 0.1, log=True),
+            "min_child_samples": trial.suggest_int("min_child_samples", 20, 100),
+            "feature_fraction": trial.suggest_float("feature_fraction", 0.5, 1.0),
+        }
+        ev_threshold = trial.suggest_float("ev_threshold", 0.8, 2.0)
+
+        summary = walk_forward_validation(
+            df,
+            win_params=win_params,
+            ev_threshold=ev_threshold,
+        )
+
+        win_recovery = summary["mean_win_recovery"]
+        win_auc = summary["mean_win_auc"]
+
+        # AUC が 0.75 未満の場合はペナルティ
+        if win_auc < 0.75:
+            return float("-inf")
+
+        logger.info(
+            "Trial %d: win_recovery=%.1f%% win_AUC=%.4f | params=%s ev_threshold=%.2f",
+            trial.number,
+            win_recovery,
+            win_auc,
+            {k: round(v, 4) if isinstance(v, float) else v for k, v in win_params.items()},
+            ev_threshold,
+        )
+        return win_recovery
+
+    return objective
+
+
+def optimize(df, n_trials: int = 50) -> dict:
+    """Optuna でパラメータを最適化し、最良パラメータを返す。"""
+    study = optuna.create_study(
+        direction="maximize",
+        sampler=optuna.samplers.TPESampler(seed=42),
+    )
+    study.optimize(build_objective(df), n_trials=n_trials, show_progress_bar=False)
+
+    best = study.best_params
+    logger.info("Best win_recovery: %.1f%%", study.best_value)
+    logger.info("Best params: %s", best)
+    return best
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Optuna ハイパーパラメータ最適化")
+    parser.add_argument("--n-trials", type=int, default=50, help="試行回数")
+    parser.add_argument("--output", type=str, default=None, help="結果を JSON で保存するパス")
+    args = parser.parse_args()
+
+    from features.feature_builder import build_training_dataset  # noqa: PLC0415
+    from model.train import DATA_START  # noqa: PLC0415
+
+    logger.info("Loading training data...")
+    df = build_training_dataset(DATA_START, date.today())
+
+    if df.empty:
+        logger.error("No training data. Abort.")
+        return
+
+    best_params = optimize(df, args.n_trials)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(best_params, f, indent=2)
+        logger.info("Saved best params to %s", args.output)
+    else:
+        print("\n=== 最良パラメータ ===")
+        print(json.dumps(best_params, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_filter/shap_analyzer.py
+++ b/ai_filter/shap_analyzer.py
@@ -1,0 +1,81 @@
+"""SHAP による特徴量重要度解析
+
+学習済みモデルの SHAP 値を計算し、特徴量ごとの重要度サマリーを返す。
+"""
+
+import logging
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def compute_shap_summary(model, X: pd.DataFrame) -> list[dict]:
+    """SHAP 値を計算して特徴量ごとのサマリーを返す。
+
+    Args:
+        model: 学習済み LightGBM モデル
+        X: 特徴量 DataFrame
+
+    Returns:
+        重要度順にソートされた特徴量サマリーのリスト:
+        [
+            {
+                "feature": str,
+                "mean_abs_shap": float,   # 平均絶対 SHAP 値（重要度）
+                "mean_shap": float,        # 平均 SHAP 値（正=勝率を上げる方向）
+                "rank": int,
+            },
+            ...
+        ]
+    """
+    import shap  # noqa: PLC0415
+
+    # TreeExplainer で SHAP 値を計算（サンプル数が多い場合はサブサンプリング）
+    sample_size = min(5000, len(X))
+    X_sample = X.sample(n=sample_size, random_state=42) if len(X) > sample_size else X
+
+    explainer = shap.TreeExplainer(model)
+    shap_values = explainer.shap_values(X_sample)
+
+    # SHAP 値の集計
+    feat_names = X.columns.tolist()
+    summary = []
+    for i, feat in enumerate(feat_names):
+        vals = shap_values[:, i]
+        summary.append(
+            {
+                "feature": feat,
+                "mean_abs_shap": float(np.mean(np.abs(vals))),
+                "mean_shap": float(np.mean(vals)),
+            }
+        )
+
+    # 重要度順にソート
+    summary.sort(key=lambda x: x["mean_abs_shap"], reverse=True)
+    for rank, item in enumerate(summary, start=1):
+        item["rank"] = rank
+
+    return summary
+
+
+def format_shap_for_claude(shap_summary: list[dict], top_n: int = 15) -> str:
+    """SHAP サマリーを Claude に渡すテキスト形式に変換する。"""
+    lines = ["## SHAP 特徴量重要度（上位）\n"]
+    lines.append(f"{'順位':>4}  {'特徴量':<35}  {'重要度':>8}  {'方向':>6}")
+    lines.append("-" * 60)
+
+    for item in shap_summary[:top_n]:
+        direction = "↑正" if item["mean_shap"] > 0 else "↓負"
+        lines.append(
+            f"{item['rank']:>4}  {item['feature']:<35}  "
+            f"{item['mean_abs_shap']:>8.4f}  {direction:>6}"
+        )
+
+    # 重要度が低い特徴量も要約
+    low_importance = [s["feature"] for s in shap_summary if s["mean_abs_shap"] < 0.001]
+    if low_importance:
+        lines.append(f"\n重要度が低い特徴量（mean_abs_shap < 0.001）: {', '.join(low_importance)}")
+
+    return "\n".join(lines)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -21,6 +21,7 @@ APScheduler==3.11.0
 
 # AI
 anthropic==0.50.0
+optuna==4.3.0
 
 # Discord
 discord.py==2.4.0

--- a/docs/design/phase4-ai-experiment-loop.md
+++ b/docs/design/phase4-ai-experiment-loop.md
@@ -1,0 +1,142 @@
+# Phase 4 設計: Optuna パラメータ最適化 + Claude 特徴量解釈ループ（v2）
+
+## 背景と設計変更
+
+初版（v1）では Claude API にパラメータチューニングをさせていたが、
+数値最適化は Optuna の方が効率的・安価。Claude の強みは「特徴量の意味解釈と提案」にある。
+
+---
+
+## 新設計: 役割分担
+
+| コンポーネント | 役割 |
+|----------------|------|
+| **Optuna** | `num_leaves`, `scale_pos_weight`, `ev_threshold` 等の数値最適化 |
+| **SHAP** | 特徴量重要度の定量計算 |
+| **Claude API** | SHAP 結果の解釈・競馬ドメイン知識を踏まえた新特徴量の提案 |
+
+---
+
+## フロー
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ フェーズ A: パラメータ最適化（Optuna）                    │
+│                                                          │
+│  Optuna trial → walk-forward → win_recovery を目標値    │
+│  → 最良パラメータを決定                                  │
+└──────────────────────────┬──────────────────────────────┘
+                            │ 最良パラメータ
+┌──────────────────────────▼──────────────────────────────┐
+│ フェーズ B: SHAP 解析                                     │
+│                                                          │
+│  最良パラメータでモデルを再学習                          │
+│  → SHAP values を計算                                    │
+│  → 特徴量ごとの重要度・方向性をサマリー化               │
+└──────────────────────────┬──────────────────────────────┘
+                            │ SHAP サマリー
+┌──────────────────────────▼──────────────────────────────┐
+│ フェーズ C: Claude による解釈・提案                       │
+│                                                          │
+│  SHAP サマリー + 過去ノウハウを Claude に渡す           │
+│  → 「なぜ効いているか」の解釈を生成                     │
+│  → 新特徴量の提案（コード仕様まで含む）                 │
+│  → ノウハウファイルに追記                               │
+└──────────────────────────┬──────────────────────────────┘
+                            │ 実装（人間 or 自動生成）
+┌──────────────────────────▼──────────────────────────────┐
+│ feature_builder_v{N}.py（特徴量バージョン管理）           │
+│  → フェーズ A に戻る                                     │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 実装コンポーネント
+
+### 1. `ai_filter/optuna_tuner.py`
+
+```python
+def optimize(df: pd.DataFrame, n_trials: int = 50) -> dict:
+    """Optuna でハイパーパラメータを最適化し最良設定を返す。"""
+    def objective(trial):
+        win_params = {
+            "num_leaves": trial.suggest_int("num_leaves", 15, 127),
+            "scale_pos_weight": trial.suggest_float("scale_pos_weight", 5.0, 30.0),
+            "learning_rate": trial.suggest_float("learning_rate", 0.01, 0.1, log=True),
+            "min_child_samples": trial.suggest_int("min_child_samples", 20, 100),
+        }
+        ev_threshold = trial.suggest_float("ev_threshold", 0.8, 2.0)
+        summary = walk_forward_validation(df, win_params=win_params, ev_threshold=ev_threshold)
+        return summary["mean_win_recovery"]
+
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=n_trials)
+    return study.best_params
+```
+
+### 2. `ai_filter/shap_analyzer.py`
+
+```python
+def compute_shap_summary(model, X: pd.DataFrame, feat_cols: list[str]) -> dict:
+    """SHAP 値を計算して特徴量ごとのサマリーを返す。
+    
+    Returns:
+        {
+            "feature_name": {
+                "mean_abs_shap": float,   # 平均絶対 SHAP 値（重要度）
+                "mean_shap": float,        # 平均 SHAP 値（正=正の影響）
+                "rank": int,               # 重要度順位
+            }
+        }
+    """
+```
+
+### 3. `ai_filter/claude_agent.py`（改修）
+
+Claude への入力:
+- SHAP サマリー（特徴量重要度ランキング + 方向性）
+- 過去の特徴量ノウハウ（`ai_filter/knowhow.md`）
+- 現在の win_recovery・AUC
+
+Claude からの出力:
+```json
+{
+  "interpretation": "popularity_rank の SHAP が最大だが...",
+  "feature_suggestions": [
+    {
+      "name": "days_to_next_grade_up",
+      "rationale": "昇級戦は過去成績との乖離が大きい...",
+      "sql_hint": "SELECT MAX(CASE WHEN class_rank > prev_class_rank THEN 1 ELSE 0 END)..."
+    }
+  ],
+  "knowhow": "【2026-04-10追記】popularity_rank はほぼ全馬に効く汎用特徴量..."
+}
+```
+
+### 4. `ai_filter/knowhow.md`
+
+Claude が蓄積するノウハウファイル。
+実験を重ねるごとに追記され、次の解釈の文脈として使用される。
+
+---
+
+## 特徴量バージョン管理
+
+```
+features/
+  feature_builder.py      ← 現行（v1）
+  feature_builder_v2.py   ← Claude 提案の特徴量を追加
+  feature_builder_v3.py   ← さらに追加
+```
+
+`train.py` / `experiment_loop.py` は `--feature-version v2` 等で切り替え可能にする。
+
+---
+
+## 実装優先順位
+
+1. `ai_filter/optuna_tuner.py` — Optuna パラメータ最適化
+2. `ai_filter/shap_analyzer.py` — SHAP 計算
+3. `ai_filter/claude_agent.py` 改修 — SHAP 解釈・提案
+4. `ai_filter/knowhow.md` + `experiment_loop.py` 改修 — 統合ループ


### PR DESCRIPTION
## Summary

- **Optuna** が数値ハイパーパラメータ探索（50 trials、Bayesian TPESampler）
- **SHAP** が特徴量重要度を定量計算し Claude に渡す形式に整形
- **Claude** が SHAP 結果を競馬ドメイン知識で解釈し、新特徴量を 2〜3 個提案
- ノウハウは `ai_filter/knowhow.md` に実験ごとに蓄積

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `ai_filter/optuna_tuner.py` | 新規: Optuna HPO（num_leaves, scale_pos_weight, learning_rate 等） |
| `ai_filter/shap_analyzer.py` | 新規: TreeExplainer + Claude向けフォーマッタ |
| `ai_filter/claude_agent.py` | 全面改修: SHAP解釈・特徴量提案・ノウハウ蓄積 |
| `ai_filter/experiment_loop.py` | 全面改修: A→B→C 統合ループ |
| `app/requirements.txt` | optuna==4.3.0 追加 |
| `docs/design/phase4-ai-experiment-loop.md` | v2 設計書 |

## 実行方法

```bash
python ai_filter/experiment_loop.py --max-iterations 3 --optuna-trials 50
```

## Test plan

- [ ] CI（ruff + pytest）がパスすること
- [ ] `optuna_tuner.py` の import が通ること（`python -c "from ai_filter.optuna_tuner import optimize"`）
- [ ] `shap_analyzer.py` の import が通ること

closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)