### PR TITLE
fix: remove duplicate verbosity kwarg in LGBMClassifier

### DIFF
--- a/ai_filter/experiment_loop.py
+++ b/ai_filter/experiment_loop.py
@@ -55,7 +55,9 @@ def run_shap_analysis(df, best_params: dict) -> tuple[list[dict], dict]:
 
     # 全データで再学習（SHAP は全体傾向を把握するため）
     y = df["win_label"]
-    model = lgb.LGBMClassifier(**win_params, n_estimators=300, random_state=42, verbosity=-1)
+    lgb_params = {**win_params, "n_estimators": 300, "random_state": 42}
+    lgb_params.setdefault("verbosity", -1)
+    model = lgb.LGBMClassifier(**lgb_params)
     model.fit(X, y)
 
     shap_summary = compute_shap_summary(model, X)


### PR DESCRIPTION
## Summary

- `WIN_PARAMS` に `verbosity: -1` が既に含まれているのに `LGBMClassifier(**win_params, verbosity=-1)` と重複渡しして `TypeError` になっていた
- `lgb_params` dict にマージしてから `setdefault` で重複を防ぐ形に修正

## Test plan

- [ ] CI パス
- [ ] `python ai_filter/experiment_loop.py --max-iterations 1 --optuna-trials 5` が SHAP フェーズを通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)